### PR TITLE
fix: return type of getStruct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC raylib raylib_cpp)
 
 # Copy assets folder to build directory
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/assets")
-    file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/assets" 
+    file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/assets"
          DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 endif()
 

--- a/src/Structures/Factory/Factory.hpp
+++ b/src/Structures/Factory/Factory.hpp
@@ -12,12 +12,12 @@ public:
     Factory();
     ~Factory() = default;
 
-    Structure::IStructure &createStructure(const std::string& type)
+    std::shared_ptr<Structure::IStructure> getStructure(const std::string& type)
     {
         if (_structureMap.find(type) == _structureMap.end()) {
             throw std::runtime_error("Structure type not found: " + type);
         }
-        return *_structureMap[type];
+        return _structureMap[type];
     }
 
     void registerStructure(const std::string& type, std::shared_ptr<Structure::IStructure> structure)


### PR DESCRIPTION
This pull request refactors the `Factory` class in `src/Structures/Factory/Factory.hpp` to improve memory management and ensure safer handling of structure objects.

Memory management improvement:

* Changed the return type of the `createStructure` method to `std::shared_ptr<Structure::IStructure>` and renamed it to `getStructure`. This ensures that shared ownership semantics are used when accessing structure objects, reducing the risk of dangling references.