### PR TITLE
Add window scaling and change map size.

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -13,7 +13,7 @@ namespace game
 {
     Game::Game(const raylib::Vector2 windowSize) :
         _window(windowSize),
-        _map(raylib::Vector2(10, 10)),
+        _map(raylib::Vector2(16, 16)),
         _isMouseInWindow(false),
         _mouseButtonLeftPressed(false),
         _mouseButtonMiddlePressed(false),

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -24,7 +24,7 @@ namespace game
     void Game::handleInput()
     {
         _lastMousePosition = _mousePosition;
-        _mousePosition = GetMousePosition();
+        _mousePosition = _window.getMousePosition();
         _mouseDelta = _mousePosition - _lastMousePosition;
 
         _mouseButtonLeftDown = IsMouseButtonDown(MOUSE_BUTTON_LEFT);
@@ -81,10 +81,8 @@ namespace game
 
     void Game::draw() const
     {
-        raylib::Window &raylibWindow = _window.getRaylibWindow();
-
-        raylibWindow.BeginDrawing();
-        raylibWindow.ClearBackground(WHITE);
+        _window.beginDraw();
+        _window.clear(raylib::Color::White());
         _map.draw(_window);
         raylib::DrawText(
             "Idle JeuConfiture Tycoon (a Jamsoft game)",
@@ -94,7 +92,7 @@ namespace game
             BLACK
         );
         _ui.draw();
-        raylibWindow.EndDrawing();
+        _window.endDraw();
     }
 
     bool Game::isRunning()

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -13,6 +13,7 @@ namespace game {
         _scale(1.0f)
     {
         createTiles();
+        setOffsetToCenter();
 
         _grassTexture = raylib::Texture(
             "assets/textures/grass.png"
@@ -165,5 +166,13 @@ namespace game {
     const raylib::Texture &Map::getGrassTexture() const
     {
         return _grassTexture;
+    }
+
+    void Map::setOffsetToCenter()
+    {
+        setOffset(raylib::Vector2(
+            1920.0f * 0.5f - _size.x * Tile::size * 0.5f,
+            1080.0f * 0.5f - _size.y * Tile::size * 0.5f
+        ));
     }
 } // game

--- a/src/Map.hpp
+++ b/src/Map.hpp
@@ -49,6 +49,8 @@ namespace game {
         [[nodiscard]] bool areAllHoveredTilesEmpty() const;
 
         [[nodiscard]] const raylib::Texture &getGrassTexture() const;
+
+        void setOffsetToCenter();
     };
 } // game
 

--- a/src/Tile.hpp
+++ b/src/Tile.hpp
@@ -20,7 +20,7 @@ namespace game {
         std::shared_ptr<Tile> _linkedTile;
 
     public:
-        static constexpr float size = 96.0f;
+        static constexpr float size = 64.0f;
 
         explicit Tile(Map &map, raylib::Vector2 position);
 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -15,9 +15,51 @@ namespace game {
             "Idle Jeuconfiture Tycoon",
             FLAG_WINDOW_RESIZABLE
         );
+        _texture = std::make_unique<raylib::RenderTexture>(
+            size.x,
+            size.y
+        );
         _window->SetTargetFPS(120);
         raylib::Window::SetExitKey(KEY_NULL);
         _isOpen = true;
+    }
+
+    void Window::beginDraw() const
+    {
+        _texture->BeginMode();
+    }
+
+    void Window::endDraw() const
+    {
+        const auto sourceRect = raylib::Rectangle(
+            0,
+            0,
+            static_cast<float>(_texture->GetTexture().width),
+            static_cast<float>(-_texture->GetTexture().height)
+        );
+        const auto destRect = raylib::Rectangle(
+            0,
+            0,
+            static_cast<float>(raylib::Window::GetWidth()),
+            static_cast<float>(raylib::Window::GetHeight())
+        );
+
+        _texture->EndMode();
+        _window->BeginDrawing();
+        _texture->GetTexture().Draw(
+            sourceRect,
+            destRect,
+            raylib::Vector2(0, 0),
+            0.0f,
+            raylib::Color::White()
+        );
+        _window->EndDrawing();
+    }
+
+    // ReSharper disable once CppMemberFunctionMayBeStatic
+    void Window::clear(const raylib::Color color) const // NOLINT(*-convert-member-functions-to-static)
+    {
+        ClearBackground(color);
     }
 
     bool Window::isOpen()
@@ -27,6 +69,21 @@ namespace game {
         }
         _isOpen = !raylib::Window::ShouldClose();
         return _isOpen;
+    }
+
+    raylib::Vector2 Window::getMousePosition() const
+    {
+        const auto xScale =
+            static_cast<float>(_texture->GetTexture().width) /
+                raylib::Window::GetSize().x;
+        const auto yScale =
+            static_cast<float>(_texture->GetTexture().height) /
+                raylib::Window::GetSize().y;
+
+        return raylib::Vector2(
+            GetMousePosition().x * xScale,
+            GetMousePosition().y * yScale
+        );
     }
 
     raylib::Window &Window::getRaylibWindow() const

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -80,9 +80,10 @@ namespace game {
             static_cast<float>(_texture->GetTexture().height) /
                 _window->GetSize().y;
 
+        const auto mousePosition = GetMousePosition();
         return {
-            GetMousePosition().x * xScale,
-            GetMousePosition().y * yScale
+            mousePosition.x * xScale,
+            mousePosition.y * yScale
         };
     }
 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -40,8 +40,8 @@ namespace game {
         const auto destRect = raylib::Rectangle(
             0,
             0,
-            static_cast<float>(raylib::Window::GetWidth()),
-            static_cast<float>(raylib::Window::GetHeight())
+            static_cast<float>(_window->GetWidth()),
+            static_cast<float>(_window->GetHeight())
         );
 
         _texture->EndMode();
@@ -75,15 +75,15 @@ namespace game {
     {
         const auto xScale =
             static_cast<float>(_texture->GetTexture().width) /
-                raylib::Window::GetSize().x;
+                _window->GetSize().x;
         const auto yScale =
             static_cast<float>(_texture->GetTexture().height) /
-                raylib::Window::GetSize().y;
+                _window->GetSize().y;
 
-        return raylib::Vector2(
+        return {
             GetMousePosition().x * xScale,
             GetMousePosition().y * yScale
-        );
+        };
     }
 
     raylib::Window &Window::getRaylibWindow() const

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -5,6 +5,8 @@
 #ifndef WINDOW_HPP
     #define WINDOW_HPP
 
+    #include <raylib-cpp.hpp>
+
     #include <memory>
     #include <Vector2.hpp>
 
@@ -17,12 +19,20 @@ namespace game
     class Window
     {
         std::unique_ptr<raylib::Window> _window;
+        std::unique_ptr<raylib::RenderTexture> _texture;
         bool _isOpen;
 
     public:
         explicit Window(raylib::Vector2 size);
 
+        void beginDraw() const;
+        void endDraw() const;
+
+        void clear(raylib::Color color) const;
+
         [[nodiscard]] bool isOpen();
+
+        [[nodiscard]] raylib::Vector2 getMousePosition() const;
 
         [[nodiscard]] raylib::Window &getRaylibWindow() const;
     };


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to improve rendering, input handling, and map scaling in the game. Key changes include introducing a render texture for improved drawing performance, centralizing the map on initialization, and adjusting tile size for better scalability. Additionally, the `Window` class has been extended with new methods to streamline rendering operations.

### Rendering Improvements:
* Added a render texture to the `Window` class for offscreen rendering, along with `beginDraw`, `endDraw`, and `clear` methods to manage the drawing process. These changes enhance rendering flexibility and performance (`src/Window.cpp`, `src/Window.hpp`). [[1]](diffhunk://#diff-2d1b7537c82c5e3e8f7ec279b41ce3643526625913c3d4138f31f3b0354e2957R18-R64) [[2]](diffhunk://#diff-2d1b7537c82c5e3e8f7ec279b41ce3643526625913c3d4138f31f3b0354e2957R74-R88) [[3]](diffhunk://#diff-0ce906c3bba58ce4d8728fb70aa25ece925fd446fdd44e3ea5a846da8399be08R22-R36)
* Updated the `Game::draw` method to use the new `Window` rendering methods, simplifying the drawing process (`src/Game.cpp`). [[1]](diffhunk://#diff-9888547a94c478fcb0f8e474cc401ca6e3e4897a1c8c808a313dfb305b888819L86-R87) [[2]](diffhunk://#diff-9888547a94c478fcb0f8e474cc401ca6e3e4897a1c8c808a313dfb305b888819L99-R97)

### Input Handling:
* Replaced direct calls to `GetMousePosition` with a new `getMousePosition` method in the `Window` class, which accounts for render texture scaling, ensuring accurate mouse input handling (`src/Window.cpp`, `src/Game.cpp`). [[1]](diffhunk://#diff-2d1b7537c82c5e3e8f7ec279b41ce3643526625913c3d4138f31f3b0354e2957R74-R88) [[2]](diffhunk://#diff-9888547a94c478fcb0f8e474cc401ca6e3e4897a1c8c808a313dfb305b888819L28-R28)

### Map and Tile Adjustments:
* Adjusted the map size from `10x10` to `16x16` for a larger playable area (`src/Game.cpp`).
* Centralized the map on initialization by introducing a `setOffsetToCenter` method in the `Map` class (`src/Map.cpp`, `src/Map.hpp`). [[1]](diffhunk://#diff-e24ae9e3b7eb08a76519640ae80241d02383d536292672591ed330a4f444d311R16) [[2]](diffhunk://#diff-e24ae9e3b7eb08a76519640ae80241d02383d536292672591ed330a4f444d311R170-R177) [[3]](diffhunk://#diff-e49168bfbd7493ae7bb07c1bbd2bd2a80ce8b441f63547f52e09ec71fe20b04bR52-R53)
* Reduced the tile size from `96.0f` to `64.0f` to improve scalability and fit more tiles within the viewport (`src/Tile.hpp`).

These changes collectively improve the game's rendering pipeline, input accuracy, and overall map presentation, laying the groundwork for a more polished and scalable gameplay experience.