### PR TITLE
feat: Add tint for background of tiles based on pollution effect.

### DIFF
--- a/src/Tile.cpp
+++ b/src/Tile.cpp
@@ -22,12 +22,21 @@ namespace game {
     {
         const auto screenPosition = getScreenPosition();
         const float textureScale = size / 512.0f * _map.getScale();
+        auto tint = raylib::Color::White();
 
+        if (hasStructure()) {
+            if (Structure::IStructure &structure = getStructure();
+                structure.getPollutionEffect() < 0) {
+                tint = raylib::Color::Green();
+            } else if (structure.getPollutionEffect() > 0) {
+                tint = raylib::Color::Red();
+            }
+        }
         _map.getGrassTexture().Draw(
             screenPosition,
             0.0f,
             textureScale,
-            raylib::Color::White()
+            tint
         );
     }
 
@@ -119,6 +128,9 @@ namespace game {
 
     Structure::IStructure &Tile::getStructure() const
     {
+        if (_linkedTile != nullptr) {
+            return _linkedTile->getStructure();
+        }
         return *_structure;
     }
 


### PR DESCRIPTION
This pull request introduces enhancements to the rendering and structure-handling logic in the `Tile` class within `src/Tile.cpp`. The key changes include adding dynamic tinting based on pollution effects and improving structure retrieval for linked tiles.

### Rendering Enhancements:
* Added a `tint` variable to dynamically adjust the tile's color based on the pollution effect of its associated structure. Green indicates a negative pollution effect (beneficial), while red indicates a positive pollution effect (harmful).

### Structure Handling Improvements:
* Updated the `getStructure()` method to return the structure from a linked tile if one exists, ensuring proper structure retrieval in cases where tiles are interconnected.